### PR TITLE
Багфикс модуля history

### DIFF
--- a/app/client/history.coffee
+++ b/app/client/history.coffee
@@ -31,7 +31,7 @@ define ['events'], (events) ->
     originPushState.apply window.history, arguments
     events.trigger "history:pushState", Array::slice.call arguments
 
-  originReplaceState = window.history.pushState
+  originReplaceState = window.history.replaceState
 
   window.history.replaceState = ->
     originReplaceState.apply window.history, arguments


### PR DESCRIPTION
Исправлена ошибка, когда при первом открытии страницы происходит форсированный скролл вверх в обход дефолтного поведения браузера
