### PR TITLE
Опция отключения первого перехода

### DIFF
--- a/app/client/app.coffee
+++ b/app/client/app.coffee
@@ -3,7 +3,6 @@
 #
 define (require) ->
   che = (customConfig) ->
-    console.log 'custom config', customConfig
     config = require "config"
     errorHanler = require "utils/errorHandlers/errorHandler"
     consoleHandler = require "utils/errorHandlers/console"

--- a/app/client/app.coffee
+++ b/app/client/app.coffee
@@ -3,6 +3,7 @@
 #
 define (require) ->
   che = (customConfig) ->
+    console.log 'custom config', customConfig
     config = require "config"
     errorHanler = require "utils/errorHandlers/errorHandler"
     consoleHandler = require "utils/errorHandlers/console"
@@ -22,6 +23,8 @@ define (require) ->
     sections = require "sections"
     clicks = require "clicks"
     loader = require "loader"
+
+    sections.init(config)
 
   # Объявляем минимально необходимый публичный интерфейс.
   che.config = require "config"

--- a/app/client/config.coffee
+++ b/app/client/config.coffee
@@ -13,6 +13,7 @@ define [
   reloadParamsDataAttributeName: "data-reload-params"
   reloadSectionsDataAttributeName: "data-reload-sections"
   baseWidgetsPath: ""
+  noFirstTransition: false
   sectionTagName: "section"
   autoScrollOnTransitions: true
   sectionSelectorAttributeName: "data-selector"

--- a/app/client/sections.coffee
+++ b/app/client/sections.coffee
@@ -14,8 +14,9 @@ define [
   "sections/cache",
   "utils/errorHandlers/errorHandler",
   "dom",
-  "widgets"
-], (history, events, sectionsLoader, Transition, cache, errorHandler, dom, widgets) ->
+  "widgets",
+  "config"
+], (history, events, sectionsLoader, Transition, cache, errorHandler, dom, widgets, config) ->
   return false if not history
   sectionIsAnimating = false
 
@@ -163,12 +164,18 @@ define [
       transitions.create(new history.CheState index: transitions.last.state.index + 1, replaceState: true)
     # here ask server for updated sections (history case)
 
-  #### Событие transition:current:update
-  #
-  # Создается первый пустой переход, он отражает текущее состояние страницы
-  #
-  events.trigger "transition:current:update", transitions.create()
 
   return {
+    init: (config) ->
+      unless config.noFirstTransition
+        #### Событие transition:current:update
+        #
+        # Создается первый пустой переход, он отражает текущее состояние страницы
+        # 10.08.2015: постепенно отказываемся от Черхитектуры. Так как страницы
+        # загружаются в обычном режиме, такой переход только создаёт проблемы,
+        # так как появляется лишний элемент в истории (на каждую загрузку!)
+        # и иногда проявляются трудноуловимые баги
+        events.trigger "transition:current:update", transitions.create()
+
     _transitions: transitions
   }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "che",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "authors": [
     "Pavel Motorin"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Che",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "engines": {
     "node": ">=0.10.13",


### PR DESCRIPTION
Так как в новой версии 4game Черхитектура будет использоваться пока для подгрузки виджетов, появилась необходимость отключать первый принудительный вызов `history.pushState()` чтобы не засорять историю навигации и избавиться от кое-каких багов